### PR TITLE
fix a lot of warning under Delphi 10.3

### DIFF
--- a/Source/TBX.pas
+++ b/Source/TBX.pas
@@ -36,6 +36,7 @@ interface
 
 uses
   Windows, Messages, Classes, SysUtils, Controls, Graphics, ImgList, Forms,
+  {$IFDEF JR_D17} UITypes,{$ENDIF}
   TB2Item, TB2Dock, TB2Toolbar, TB2ToolWindow, TB2Anim, TBXUtils, TBXThemes;
 
 const
@@ -785,12 +786,23 @@ var
   BufDC: HDC;
   BufDCRec: TBufDCRec;
   ResultOK: Boolean;
+  {$IFDEF JR_D7}
+  IsThemesEnabled: Boolean;
+  {$ENDIF}
 begin
   if Control = nil then Exit;
+  {$IFDEF JR_D7}
+  IsThemesEnabled :=
+    {$IF  CompilerVersion >= 33}
+    StyleServices.Enabled;
+    {$ELSE}
+    ThemeServices.ThemesEnabled;
+    {$IFEND}
+  {$ENDIF}
   Parent := Control.Parent;
   if (Parent <> nil) and Parent.HandleAllocated then
   begin
-    if {$IFDEF JR_D7}(ThemeServices.ThemesEnabled or USE_THEMES){$ELSE}USE_THEMES{$ENDIF} and
+    if {$IFDEF JR_D7}(IsThemesEnabled or USE_THEMES){$ELSE}USE_THEMES{$ENDIF} and
       (Parent is TTabSheet){special case} then goto DrawTabSheet;
 
     SetPoint(R2.TopLeft, 0, 0);
@@ -800,7 +812,7 @@ begin
     SetWindowOrgEx(DC, R2.Left, R2.Top, nil);
     if ResultOK then Exit;
 
-    if {$IFDEF JR_D7}(ThemeServices.ThemesEnabled or USE_THEMES){$ELSE}USE_THEMES{$ENDIF} and
+    if {$IFDEF JR_D7}(IsThemesEnabled or USE_THEMES){$ELSE}USE_THEMES{$ENDIF} and
       (Control is TWinControl) then
     begin
       DrawTabSheet:
@@ -809,7 +821,7 @@ begin
       BufDC := CreateBufDC(DC, R2.Right, R2.Bottom, BufDCRec);
       { Fortunately, DrawThemeParentBackground has no problems if DC is memory DC }
       {$IFDEF JR_D7}
-      if ThemeServices.ThemesEnabled then
+      if IsThemesEnabled then
         ResultOK := UxTheme.DrawThemeParentBackground(TWinControl(Control).Handle, BufDC, @R2) = S_OK
       else
         ResultOK := TBXUxThemes.DrawThemeParentBackground(TWinControl(Control).Handle, BufDC, @R2) = S_OK;

--- a/Source/TBXDkPanels.pas
+++ b/Source/TBXDkPanels.pas
@@ -32,7 +32,8 @@ interface
 
 uses
   Windows, Messages, Classes, Graphics, Controls, StdCtrls, ExtCtrls, Forms,
-  TB2Dock, TB2Item, TBX, TBXThemes, ImgList, Menus;
+  ImgList, Menus, {$IFDEF JR_D17} UITypes,{$ENDIF}
+  TB2Dock, TB2Item, TBX, TBXThemes;
 
 const
   { New hit test constants for page scrollers }
@@ -1301,11 +1302,11 @@ var
   NewDockList: TList;
   PosData: array of TPosRec;
   LeftRight: Boolean;
-  I, J, K, L, DragIndex, ResizeIndex, ForcedWidth: Integer;
+  I, J, K, DragIndex, ResizeIndex: Integer;
   EmptySize, ClientW, ClientH, DockSize, TotalSize, TotalMinimumSize, TotalMaximumSize: Integer;
   T: TTBXDockablePanel;
   S: TPoint;
-  CurRowPixel, CurRowSize: Integer;
+  CurRowSize: Integer;
   StretchPanelCount: Integer;
   Stretching: Boolean;
   AccDelta, Acc: Extended;

--- a/Source/Themes/TBXDefaultTheme.pas
+++ b/Source/Themes/TBXDefaultTheme.pas
@@ -31,7 +31,8 @@ interface
 {$I TBX.inc}
 
 uses
-  Windows, Messages, Graphics, TBXThemes, ImgList;
+  Windows, Messages, Graphics, ImgList, {$IFDEF JR_D17} UITypes,{$ENDIF}
+  TBXThemes;
 
 type
   TTBXDefaultTheme = class(TTBXTheme)


### PR DESCRIPTION
> [dcc32 Hint] TBXDefaultTheme.pas(1524): H2443 Inline function 'TPen.GetColor' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TBX.pas(1220): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TBX.pas(1629): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list
[dcc32 Hint] TBXDkPanels.pas(3591): H2443 Inline function 'TFont.GetStyle' has not been expanded because unit 'System.UITypes' is not specified in USES list